### PR TITLE
Allow empty username/password for MQTT

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -59,8 +59,8 @@ schema:
   connector_password_trionity: password?
   connector_interval_trionity: int(60,3600)?
   connector_spin_trionity: match(^\d{4}$)?
-  mqtt_username: str
-  mqtt_password: password
+  mqtt_username: str?
+  mqtt_password: password?
   mqtt_broker: str
   log_level: list(info|warning|error|debug)
   connector_username_webui: str


### PR DESCRIPTION
Allow empty username/password for MQTT, as they are not required for every MQTT installation/configuration