### PR TITLE
Add per-component logging overrides to add-on

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -148,6 +148,26 @@ Definieren Sie die Menge an Informationen, die in Protokollen aufgezeichnet wurd
 -   `Error`: Zeigt nur Fehlermeldungen an.
 -   `Debug`: Zeigt zusätzliche Details an, die für die Fehlerbehebung nützlich sind.
 
+### Erweiterte Protokollierungsüberschreibungen
+
+Standardmäßig werden die globalen Protokollierungseinstellungen verwendet. In `logs.advanced` können Sie die Protokollstufe für einen einzelnen konfigurierten Connector oder ein Plugin überschreiben, während alles andere die globale Einstellung beibehält.
+
+Verwenden Sie `default`, um die globale Einstellung zu übernehmen. Um beispielsweise nur das erste konfigurierte Fahrzeugkonto zu debuggen, während der Rest auf `info` bleibt:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Dadurch wird die Debug-Protokollierung nur für das erste konfigurierte Fahrzeugkonto aktiviert, während der Rest des Add-ons weiterhin die globale Stufe `info` verwendet.
+
+Connector-Überschreibungen sind für `brand1`, `brand2` und `volvo` verfügbar. Plugin-Überschreibungen sind für `mqtt`, `webui`, `abrp` und `mqtt_homeassistant` verfügbar.
+
 ### 7. `ABRP - A Better Routeplanner`
 
 Für jedes Fahrzeug, das Sie mit ABRP (A Better Routeplanner) verbinden möchten, müssen Sie eine eindeutige Kennung für jedes Fahrzeug (`vin`) sowie ein Authentifizierungstoken (`token`) angeben. Diese Wertpaare ermöglichen die Zuordnung zwischen Ihrem Fahrzeug und seinem Token im ABRP-System.

--- a/README.es.md
+++ b/README.es.md
@@ -144,6 +144,26 @@ Defina la cantidad de información registrada en los registros:
 -   `Error`: Muestra solo mensajes de error.
 -   `Debug`: Muestra detalles adicionales útiles para solucionar problemas.
 
+### Anulaciones avanzadas de registro
+
+De forma predeterminada se utilizan los ajustes globales de registro. En `logs.advanced`, puedes anular el nivel de registro de un único conector o plugin configurado, mientras todo lo demás mantiene la configuración global.
+
+Usa `default` para heredar la configuración global. Por ejemplo, para depurar solo la primera cuenta de vehículo configurada y mantener el resto en `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Esto activa el registro de depuración solo para la primera cuenta de vehículo configurada, mientras que el resto del complemento sigue utilizando el nivel global `info`.
+
+Las anulaciones de conectores están disponibles para `brand1`, `brand2` y `volvo`. Las anulaciones de plugins están disponibles para `mqtt`, `webui`, `abrp` y `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 Para cada vehículo que desea conectarse a ABRP (un mejor rutinPlanner), debe proporcionar un identificador único para cada vehículo (`vin`) así como un token de autenticación (`token`). Estos pares de valores le permiten establecer una coincidencia entre su vehículo y su token en el sistema ABRP.

--- a/README.fr.md
+++ b/README.fr.md
@@ -148,6 +148,26 @@ Définissez la quantité d'informations enregistrées dans les journaux:
 -   `Error`: Affiche uniquement les messages d'erreur.
 -   `Debug`: Affiche des détails supplémentaires utiles pour le dépannage.
 
+### Paramètres avancés de journalisation
+
+Les paramètres globaux de journalisation sont utilisés par défaut. Dans `logs.advanced`, vous pouvez remplacer le niveau de journalisation d'un seul connecteur ou plugin configuré, tandis que tout le reste conserve le paramètre global.
+
+Utilisez `default` pour hériter du paramètre global. Par exemple, pour déboguer uniquement le premier compte véhicule configuré tout en gardant le reste sur `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Cela active la journalisation de débogage uniquement pour le premier compte véhicule configuré, tandis que le reste de l'add-on continue d'utiliser le niveau global `info`.
+
+Les remplacements de connecteur sont disponibles pour `brand1`, `brand2` et `volvo`. Les remplacements de plugin sont disponibles pour `mqtt`, `webui`, `abrp` et `mqtt_homeassistant`.
+
 ### 7. `ABRP - A Better Routeplanner`
 
 Pour chaque véhicule que vous souhaitez connecter à ABRP (A Better Routeplanner), vous devez fournir un identifiant unique pour chaque véhicule (`vin`) ainsi qu'un jeton d'authentification (`token`). Ces paires de valeurs permettent d'établir une correspondance entre votre véhicule et son token dans le système ABRP.

--- a/README.it.md
+++ b/README.it.md
@@ -144,6 +144,26 @@ Definire la quantità di informazioni registrate nei registri:
 -   `Error`: Visualizza solo i messaggi di errore.
 -   `Debug`: Visualizza ulteriori dettagli utili per la risoluzione dei problemi.
 
+### Impostazioni avanzate di registrazione
+
+Per impostazione predefinita vengono usate le impostazioni globali di registrazione. In `logs.advanced` puoi sovrascrivere il livello di log per un singolo connettore o plugin configurato, mentre tutto il resto mantiene l'impostazione globale.
+
+Usa `default` per ereditare l'impostazione globale. Ad esempio, per eseguire il debug solo del primo account veicolo configurato mantenendo il resto su `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Questo abilita la registrazione di debug solo per il primo account veicolo configurato, mentre il resto dell'add-on continua a usare il livello globale `info`.
+
+Le sovrascritture dei connettori sono disponibili per `brand1`, `brand2` e `volvo`. Le sovrascritture dei plugin sono disponibili per `mqtt`, `webui`, `abrp` e `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 Per ogni veicolo che si desidera connettere ad ABRP (un percorso migliore), è necessario fornire un identificatore univoco per ciascun veicolo (`vin`) così come un token di autenticazione (`token`). Queste coppie di valori consentono di stabilire una corrispondenza tra il veicolo e il suo token nel sistema ABRP.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ Define the amount of information recorded in logs:
 - `Error`: Displays only error messages.
 - `Debug`: Displays additional details useful for troubleshooting.
 
+### Advanced Logging Overrides
+The global logging settings are used by default. In `logs.advanced`, you can override the log level for a single configured connector or plugin while keeping everything else at the global level.
+
+Use `default` to inherit the global setting. For example, to debug only the first configured vehicle account while keeping the rest at `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Connector overrides are available for `brand1`, `brand2`, and `volvo`. Plugin overrides are available for `mqtt`, `webui`, `abrp`, and `mqtt_homeassistant`.
+
 ### 7. `ABRP - A Better Routeplanner`
 
 For each vehicle you wish to connect to ABRP (A Better Routeplanner), you must provide a unique identifier for each vehicle (`vin`) as well as an authentication token (`token`). These pairs of values allow you to establish a match between your vehicle and its token in the ABRP system.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ logs:
       api_log_level: debug
 ```
 
+This enables debug logging only for the first configured vehicle account while the rest of the add-on continues to use the global `info` level.
+
 Connector overrides are available for `brand1`, `brand2`, and `volvo`. Plugin overrides are available for `mqtt`, `webui`, `abrp`, and `mqtt_homeassistant`.
 
 ### 7. `ABRP - A Better Routeplanner`

--- a/README.nl.md
+++ b/README.nl.md
@@ -144,6 +144,26 @@ Definieer de hoeveelheid informatie die is vastgelegd in logboeken:
 -   `Error`: Geeft alleen foutmeldingen weer.
 -   `Debug`: Toont aanvullende details die nuttig zijn voor het oplossen van problemen.
 
+### Geavanceerde instellingen voor logboekregistratie
+
+Standaard worden de globale logboekinstellingen gebruikt. In `logs.advanced` kun je het logboekniveau voor één geconfigureerde connector of plug-in overschrijven, terwijl al het overige de globale instelling blijft gebruiken.
+
+Gebruik `default` om de globale instelling over te nemen. Bijvoorbeeld om alleen het eerste geconfigureerde voertuigaccount te debuggen en de rest op `info` te laten staan:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Hiermee wordt debug-logboekregistratie alleen ingeschakeld voor het eerste geconfigureerde voertuigaccount, terwijl de rest van de add-on het globale niveau `info` blijft gebruiken.
+
+Connector-overschrijvingen zijn beschikbaar voor `brand1`, `brand2` en `volvo`. Plug-in-overschrijvingen zijn beschikbaar voor `mqtt`, `webui`, `abrp` en `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 Voor elk voertuig dat u wilt aansluiten op ABRP (een betere routeplanner), moet u voor elk voertuig een unieke identificatie geven (`vin`) evenals een authenticatietoken (`token`). Met deze paren waarden kunt u een match tussen uw voertuig en het token in het ABRP -systeem vaststellen.

--- a/README.no.md
+++ b/README.no.md
@@ -144,6 +144,26 @@ Definer mengden informasjon registrert i logger:
 -   `Error`: Viser bare feilmeldinger.
 -   `Debug`: Viser ytterligere detaljer som er nyttige for feilsøking.
 
+### Avanserte innstillinger for loggføring
+
+De globale logginnstillingene brukes som standard. I `logs.advanced` kan du overstyre loggnivået for én konfigurert kobling eller plugin, mens alt annet beholder den globale innstillingen.
+
+Bruk `default` for å arve den globale innstillingen. For eksempel, for å feilsøke bare den første konfigurerte kjøretøykontoen mens resten forblir på `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Dette aktiverer feilsøkingslogging bare for den første konfigurerte kjøretøykontoen, mens resten av tillegget fortsatt bruker det globale nivået `info`.
+
+Koblingsoverstyringer er tilgjengelige for `brand1`, `brand2` og `volvo`. Plugin-overstyringer er tilgjengelige for `mqtt`, `webui`, `abrp` og `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 For hvert kjøretøy du ønsker å koble til ABRP (en bedre ruteplan), må du gi en unik identifikator for hvert kjøretøy (`vin`) samt en autentiseringstoken (`token`). Disse verdiene lar deg etablere en kamp mellom kjøretøyet og dets token i ABRP -systemet.

--- a/README.pl.md
+++ b/README.pl.md
@@ -144,6 +144,26 @@ Zdefiniuj ilość informacji zarejestrowanych w dziennikach:
 -   `Error`: Wyświetla tylko komunikaty o błędach.
 -   `Debug`: Wyświetla dodatkowe szczegóły przydatne do rozwiązywania problemów.
 
+### Zaawansowane opcje nadpisywania logów
+
+Domyślnie używane są globalne ustawienia logowania. W `logs.advanced` można nadpisać poziom logowania dla pojedynczego skonfigurowanego konektora lub pluginu, podczas gdy wszystko inne pozostaje przy ustawieniu globalnym.
+
+Użyj `default`, aby odziedziczyć ustawienie globalne. Na przykład, aby debugować tylko pierwsze skonfigurowane konto pojazdu, pozostawiając resztę na poziomie `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Włącza to logowanie debugowania tylko dla pierwszego skonfigurowanego konta pojazdu, podczas gdy reszta dodatku nadal używa globalnego poziomu `info`.
+
+Nadpisania konektorów są dostępne dla `brand1`, `brand2` i `volvo`. Nadpisania pluginów są dostępne dla `mqtt`, `webui`, `abrp` i `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 Dla każdego pojazdu, który chcesz połączyć z ABRP (lepszy planner trasy), musisz podać unikalny identyfikator dla każdego pojazdu (`vin`) a także token uwierzytelniający (`token`). Te pary wartości pozwalają ustalić dopasowanie między pojazdem a jego tokenem w systemie ABRP.

--- a/README.pt.md
+++ b/README.pt.md
@@ -144,6 +144,26 @@ Defina a quantidade de informações registradas em logs:
 -   `Error`: Exibe apenas mensagens de erro.
 -   `Debug`: Exibe detalhes adicionais úteis para solução de problemas.
 
+### Substituições avançadas de registo
+
+As definições globais de registo são utilizadas por predefinição. Em `logs.advanced`, pode substituir o nível de registo de um único conector ou plugin configurado, enquanto todo o resto mantém a definição global.
+
+Use `default` para herdar a definição global. Por exemplo, para depurar apenas a primeira conta de veículo configurada, mantendo as restantes em `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Isto ativa o registo de depuração apenas para a primeira conta de veículo configurada, enquanto o resto do add-on continua a usar o nível global `info`.
+
+As substituições de conectores estão disponíveis para `brand1`, `brand2` e `volvo`. As substituições de plugins estão disponíveis para `mqtt`, `webui`, `abrp` e `mqtt_homeassistant`.
+
 ### 7.`ABRP - A Better Routeplanner`
 
 Para cada veículo que você deseja conectar ao ABRP (um melhor planejador de rota), você deve fornecer um identificador exclusivo para cada veículo (`vin`), bem como um token de autenticação (`token`). Esses pares de valores permitem estabelecer uma correspondência entre seu veículo e seu token no sistema ABRP.

--- a/carconnectivity-addon/DOCS.md
+++ b/carconnectivity-addon/DOCS.md
@@ -125,6 +125,23 @@ Define the amount of information recorded in logs:
 - `Error`: Displays only error messages.
 - `Debug`: Displays additional details useful for troubleshooting.
 
+### Advanced Logging Overrides
+The global logging settings are used by default. In `logs.advanced`, you can override the log level for a single configured connector or plugin while keeping everything else at the global level.
+
+Use `default` to inherit the global setting. For example, to debug only the first configured vehicle account while keeping the rest at `info`:
+
+```yaml
+logs:
+  level: info
+  api_level: info
+  advanced:
+    brand1:
+      log_level: debug
+      api_log_level: debug
+```
+
+Connector overrides are available for `brand1`, `brand2`, and `volvo`. Plugin overrides are available for `mqtt`, `webui`, `abrp`, and `mqtt_homeassistant`.
+
 ### 7. `ABRP - A Better Routeplanner`
 
 For each vehicle you wish to connect to ABRP (A Better Routeplanner), you must provide a unique identifier for each vehicle (`vin`) as well as an authentication token (`token`). These pairs of values allow you to establish a match between your vehicle and its token in the ABRP system.

--- a/carconnectivity-addon/DOCS.md
+++ b/carconnectivity-addon/DOCS.md
@@ -140,6 +140,8 @@ logs:
       api_log_level: debug
 ```
 
+This enables debug logging only for the first configured vehicle account while the rest of the add-on continues to use the global `info` level.
+
 Connector overrides are available for `brand1`, `brand2`, and `volvo`. Plugin overrides are available for `mqtt`, `webui`, `abrp`, and `mqtt_homeassistant`.
 
 ### 7. `ABRP - A Better Routeplanner`

--- a/carconnectivity-addon/config.yaml
+++ b/carconnectivity-addon/config.yaml
@@ -48,6 +48,24 @@ options:
   logs:
     level: "info"
     api_level: "info"
+    advanced:
+      brand1:
+        log_level: "default"
+        api_log_level: "default"
+      brand2:
+        log_level: "default"
+        api_log_level: "default"
+      volvo:
+        log_level: "default"
+        api_log_level: "default"
+      mqtt:
+        log_level: "default"
+      webui:
+        log_level: "default"
+      abrp:
+        log_level: "default"
+      mqtt_homeassistant:
+        log_level: "default"
   expert: false
 schema:
   brand1:
@@ -85,5 +103,23 @@ schema:
   logs:
     level: list(info|warning|error|debug)
     api_level: list(info|warning|error|debug)
+    advanced:
+      brand1:
+        log_level: list(default|info|warning|error|debug)
+        api_log_level: list(default|info|warning|error|debug)
+      brand2:
+        log_level: list(default|info|warning|error|debug)
+        api_log_level: list(default|info|warning|error|debug)
+      volvo:
+        log_level: list(default|info|warning|error|debug)
+        api_log_level: list(default|info|warning|error|debug)
+      mqtt:
+        log_level: list(default|info|warning|error|debug)
+      webui:
+        log_level: list(default|info|warning|error|debug)
+      abrp:
+        log_level: list(default|info|warning|error|debug)
+      mqtt_homeassistant:
+        log_level: list(default|info|warning|error|debug)
   expert: bool
 

--- a/carconnectivity-addon/rootfs/tmp/carconnectivity.json.gtpl
+++ b/carconnectivity-addon/rootfs/tmp/carconnectivity.json.gtpl
@@ -6,6 +6,9 @@
             {
                 "type": "{{ if or (eq .brand1.type "seat") (eq .brand1.type "cupra") }}seatcupra{{ else }}{{ .brand1.type }}{{ end }}",
                 "config": {
+                    {{- if and .logs.advanced.brand1.log_level (ne .logs.advanced.brand1.log_level "default") }}
+                    "log_level": "{{ .logs.advanced.brand1.log_level }}",
+                    {{- end }}
                     {{- if or (eq .brand1.type "seat") (eq .brand1.type "cupra") }}
                     "brand": "{{ .brand1.type }}",
                     {{- end }}
@@ -16,7 +19,7 @@
                     "password": "{{ .brand1.password }}",
                     "interval": {{ .brand1.interval }},
                     "spin": "{{ .brand1.spin }}",
-                    "api_log_level": "{{ .logs.api_level }}"
+                    "api_log_level": "{{ if and .logs.advanced.brand1.api_log_level (ne .logs.advanced.brand1.api_log_level "default") }}{{ .logs.advanced.brand1.api_log_level }}{{ else }}{{ .logs.api_level }}{{ end }}"
                 }
             }
             {{- end }}
@@ -26,6 +29,9 @@
                 "type": "{{ if or (eq .brand2.type "seat") (eq .brand2.type "cupra") }}seatcupra{{ else }}{{ .brand2.type }}{{ end }}",
                 "connector_id": "{{ .brand2.type }}2",
                 "config": {
+                    {{- if and .logs.advanced.brand2.log_level (ne .logs.advanced.brand2.log_level "default") }}
+                    "log_level": "{{ .logs.advanced.brand2.log_level }}",
+                    {{- end }}
                     {{- if or (eq .brand2.type "seat") (eq .brand2.type "cupra") }}
                     "brand": "{{ .brand2.type }}",
                     {{- end }}
@@ -36,7 +42,7 @@
                     "password": "{{ .brand2.password }}",
                     "interval": {{ .brand2.interval }},
                     "spin": "{{ .brand2.spin }}",
-                    "api_log_level": "{{ .logs.api_level }}"
+                    "api_log_level": "{{ if and .logs.advanced.brand2.api_log_level (ne .logs.advanced.brand2.api_log_level "default") }}{{ .logs.advanced.brand2.api_log_level }}{{ else }}{{ .logs.api_level }}{{ end }}"
                 }
             }
             {{- end }}
@@ -45,12 +51,15 @@
             {
                 "type": "volvo",
                 "config": {
+                    {{- if and .logs.advanced.volvo.log_level (ne .logs.advanced.volvo.log_level "default") }}
+                    "log_level": "{{ .logs.advanced.volvo.log_level }}",
+                    {{- end }}
                     "key_primary": "{{ .volvo.key_primary }}",
                     "key_secondary": "{{ .volvo.key_secondary }}",
                     "connected_volvo_vehicle_token": "{{ .volvo.vehicle_token }}",
                     "location_token": "{{ .volvo.location_token }}",
                     "interval": {{ .volvo.interval }},
-                    "api_log_level": "{{ .logs.api_level }}"
+                    "api_log_level": "{{ if and .logs.advanced.volvo.api_log_level (ne .logs.advanced.volvo.api_log_level "default") }}{{ .logs.advanced.volvo.api_log_level }}{{ else }}{{ .logs.api_level }}{{ end }}"
                 }
             }
             {{- end }}
@@ -82,7 +91,7 @@
                     "port": {{ .mqtt.port }},
                     "locale": "en_US",
                     "time_format": "%Y-%m-%dT%H:%M:%S%z",
-                    "log_level": "{{ .logs.level }}"
+                    "log_level": "{{ if and .logs.advanced.mqtt.log_level (ne .logs.advanced.mqtt.log_level "default") }}{{ .logs.advanced.mqtt.log_level }}{{ else }}{{ .logs.level }}{{ end }}"
                 }
             },
             {
@@ -103,7 +112,7 @@
                         {{- end }}
                         },
                     "locale": "en_US",
-                    "log_level": "{{ .logs.level }}"
+                    "log_level": "{{ if and .logs.advanced.webui.log_level (ne .logs.advanced.webui.log_level "default") }}{{ .logs.advanced.webui.log_level }}{{ else }}{{ .logs.level }}{{ end }}"
                 }
             },
             {
@@ -122,7 +131,7 @@
                             {{- $first = false }}
                         {{- end }}
                     },
-                    "log_level": "{{ .logs.level }}"
+                    "log_level": "{{ if and .logs.advanced.abrp.log_level (ne .logs.advanced.abrp.log_level "default") }}{{ .logs.advanced.abrp.log_level }}{{ else }}{{ .logs.level }}{{ end }}"
                 }
             },
             {
@@ -130,7 +139,7 @@
                 "config": {
                     "locale": "en_US",
                     "time_format": "%Y-%m-%dT%H:%M:%S%z",
-                    "log_level": "{{ .logs.level }}"
+                    "log_level": "{{ if and .logs.advanced.mqtt_homeassistant.log_level (ne .logs.advanced.mqtt_homeassistant.log_level "default") }}{{ .logs.advanced.mqtt_homeassistant.log_level }}{{ else }}{{ .logs.level }}{{ end }}"
                 }
             }
         ]

--- a/carconnectivity-addon/translations/de.yaml
+++ b/carconnectivity-addon/translations/de.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "API-Ebene"
         description: "Protokollierungsniveau spezifisch für APIs."
+      advanced:
+        name: "Erweiterte Protokollierungsüberschreibungen"
+        description: "Optionale Protokollstufen pro Connector und Plugin. Verwenden Sie default, um die globalen Protokollierungseinstellungen zu übernehmen."
+        fields:
+          brand1:
+            name: "Fahrzeugkonto 1"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+              api_log_level:
+                name: "API-Protokollstufe"
+          brand2:
+            name: "Fahrzeugkonto 2"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+              api_log_level:
+                name: "API-Protokollstufe"
+          volvo:
+            name: "Volvo-Connector"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+              api_log_level:
+                name: "API-Protokollstufe"
+          mqtt:
+            name: "MQTT-Plugin"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+          webui:
+            name: "Web-UI-Plugin"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+          abrp:
+            name: "ABRP-Plugin"
+            fields:
+              log_level:
+                name: "Protokollstufe"
+          mqtt_homeassistant:
+            name: "MQTT-Home-Assistant-Plugin"
+            fields:
+              log_level:
+                name: "Protokollstufe"
 
   # --- EXPERT OPTION ---
   expert:

--- a/carconnectivity-addon/translations/de.yaml
+++ b/carconnectivity-addon/translations/de.yaml
@@ -124,7 +124,7 @@ configuration:
         description: "Protokollierungsniveau spezifisch für APIs."
       advanced:
         name: "Erweiterte Protokollierungsüberschreibungen"
-        description: "Optionale Protokollstufen pro Connector und Plugin. Verwenden Sie default, um die globalen Protokollierungseinstellungen zu übernehmen."
+        description: "Optionale Protokollstufen pro Connector und pro Plugin. Verwenden Sie default, um die globalen Protokollierungseinstellungen zu übernehmen."
         fields:
           brand1:
             name: "Fahrzeugkonto 1"

--- a/carconnectivity-addon/translations/en.yaml
+++ b/carconnectivity-addon/translations/en.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "API level"
         description: "Logging level specific to APIs."
+      advanced:
+        name: "Advanced logging overrides"
+        description: "Optional per-connector and per-plugin log levels. Use default to inherit the global logging settings."
+        fields:
+          brand1:
+            name: "Vehicle account 1"
+            fields:
+              log_level:
+                name: "Log level"
+              api_log_level:
+                name: "API log level"
+          brand2:
+            name: "Vehicle account 2"
+            fields:
+              log_level:
+                name: "Log level"
+              api_log_level:
+                name: "API log level"
+          volvo:
+            name: "Volvo connector"
+            fields:
+              log_level:
+                name: "Log level"
+              api_log_level:
+                name: "API log level"
+          mqtt:
+            name: "MQTT plugin"
+            fields:
+              log_level:
+                name: "Log level"
+          webui:
+            name: "Web UI plugin"
+            fields:
+              log_level:
+                name: "Log level"
+          abrp:
+            name: "ABRP plugin"
+            fields:
+              log_level:
+                name: "Log level"
+          mqtt_homeassistant:
+            name: "MQTT Home Assistant plugin"
+            fields:
+              log_level:
+                name: "Log level"
 
   # --- EXPERT OPTION ---
   expert:

--- a/carconnectivity-addon/translations/es.yaml
+++ b/carconnectivity-addon/translations/es.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "Nivel de APIs"
         description: "Nivel de registro específico para las APIs."
+      advanced:
+        name: "Anulaciones avanzadas de registro"
+        description: "Niveles de registro opcionales por conector y por plugin. Usa default para heredar la configuración global de registro."
+        fields:
+          brand1:
+            name: "Cuenta de vehículo 1"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+              api_log_level:
+                name: "Nivel de registro de API"
+          brand2:
+            name: "Cuenta de vehículo 2"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+              api_log_level:
+                name: "Nivel de registro de API"
+          volvo:
+            name: "Conector Volvo"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+              api_log_level:
+                name: "Nivel de registro de API"
+          mqtt:
+            name: "Plugin MQTT"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+          webui:
+            name: "Plugin de interfaz web"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+          abrp:
+            name: "Plugin ABRP"
+            fields:
+              log_level:
+                name: "Nivel de registro"
+          mqtt_homeassistant:
+            name: "Plugin MQTT Home Assistant"
+            fields:
+              log_level:
+                name: "Nivel de registro"
 
   # --- OPCIÓN EXPERT ---
   expert:

--- a/carconnectivity-addon/translations/es.yaml
+++ b/carconnectivity-addon/translations/es.yaml
@@ -123,7 +123,7 @@ configuration:
         name: "Nivel de APIs"
         description: "Nivel de registro específico para las APIs."
       advanced:
-        name: "Anulaciones avanzadas de registro"
+        name: "Configuraciones avanzadas de registro"
         description: "Niveles de registro opcionales por conector y por plugin. Usa default para heredar la configuración global de registro."
         fields:
           brand1:
@@ -132,21 +132,21 @@ configuration:
               log_level:
                 name: "Nivel de registro"
               api_log_level:
-                name: "Nivel de registro de API"
+                name: "Nivel de registro de la API"
           brand2:
             name: "Cuenta de vehículo 2"
             fields:
               log_level:
                 name: "Nivel de registro"
               api_log_level:
-                name: "Nivel de registro de API"
+                name: "Nivel de registro de la API"
           volvo:
             name: "Conector Volvo"
             fields:
               log_level:
                 name: "Nivel de registro"
               api_log_level:
-                name: "Nivel de registro de API"
+                name: "Nivel de registro de la API"
           mqtt:
             name: "Plugin MQTT"
             fields:

--- a/carconnectivity-addon/translations/fr.yaml
+++ b/carconnectivity-addon/translations/fr.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "Niveau des API"
         description: "Niveau de journalisation spécifique pour les API."
+      advanced:
+        name: "Remplacements avancés de journalisation"
+        description: "Niveaux de journalisation facultatifs par connecteur et par plugin. Utilisez default pour hériter des paramètres globaux de journalisation."
+        fields:
+          brand1:
+            name: "Compte véhicule 1"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+              api_log_level:
+                name: "Niveau de journalisation API"
+          brand2:
+            name: "Compte véhicule 2"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+              api_log_level:
+                name: "Niveau de journalisation API"
+          volvo:
+            name: "Connecteur Volvo"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+              api_log_level:
+                name: "Niveau de journalisation API"
+          mqtt:
+            name: "Plugin MQTT"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+          webui:
+            name: "Plugin interface web"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+          abrp:
+            name: "Plugin ABRP"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
+          mqtt_homeassistant:
+            name: "Plugin MQTT Home Assistant"
+            fields:
+              log_level:
+                name: "Niveau de journalisation"
 
   # --- OPTION EXPERT ---
   expert:

--- a/carconnectivity-addon/translations/fr.yaml
+++ b/carconnectivity-addon/translations/fr.yaml
@@ -123,7 +123,7 @@ configuration:
         name: "Niveau des API"
         description: "Niveau de journalisation spécifique pour les API."
       advanced:
-        name: "Remplacements avancés de journalisation"
+        name: "Paramètres avancés de journalisation"
         description: "Niveaux de journalisation facultatifs par connecteur et par plugin. Utilisez default pour hériter des paramètres globaux de journalisation."
         fields:
           brand1:
@@ -132,21 +132,21 @@ configuration:
               log_level:
                 name: "Niveau de journalisation"
               api_log_level:
-                name: "Niveau de journalisation API"
+                name: "Niveau de journalisation de l'API"
           brand2:
             name: "Compte véhicule 2"
             fields:
               log_level:
                 name: "Niveau de journalisation"
               api_log_level:
-                name: "Niveau de journalisation API"
+                name: "Niveau de journalisation de l'API"
           volvo:
             name: "Connecteur Volvo"
             fields:
               log_level:
                 name: "Niveau de journalisation"
               api_log_level:
-                name: "Niveau de journalisation API"
+                name: "Niveau de journalisation de l'API"
           mqtt:
             name: "Plugin MQTT"
             fields:

--- a/carconnectivity-addon/translations/it.yaml
+++ b/carconnectivity-addon/translations/it.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "Livello API"
         description: "Livello di registrazione specifico per le API."
+      advanced:
+        name: "Override avanzati della registrazione"
+        description: "Livelli di log opzionali per connettore e per plugin. Usa default per ereditare le impostazioni globali di registrazione."
+        fields:
+          brand1:
+            name: "Account veicolo 1"
+            fields:
+              log_level:
+                name: "Livello di log"
+              api_log_level:
+                name: "Livello di log API"
+          brand2:
+            name: "Account veicolo 2"
+            fields:
+              log_level:
+                name: "Livello di log"
+              api_log_level:
+                name: "Livello di log API"
+          volvo:
+            name: "Connettore Volvo"
+            fields:
+              log_level:
+                name: "Livello di log"
+              api_log_level:
+                name: "Livello di log API"
+          mqtt:
+            name: "Plugin MQTT"
+            fields:
+              log_level:
+                name: "Livello di log"
+          webui:
+            name: "Plugin interfaccia web"
+            fields:
+              log_level:
+                name: "Livello di log"
+          abrp:
+            name: "Plugin ABRP"
+            fields:
+              log_level:
+                name: "Livello di log"
+          mqtt_homeassistant:
+            name: "Plugin MQTT Home Assistant"
+            fields:
+              log_level:
+                name: "Livello di log"
 
   # --- OPZIONE EXPERT ---
   expert:

--- a/carconnectivity-addon/translations/it.yaml
+++ b/carconnectivity-addon/translations/it.yaml
@@ -123,8 +123,8 @@ configuration:
         name: "Livello API"
         description: "Livello di registrazione specifico per le API."
       advanced:
-        name: "Override avanzati della registrazione"
-        description: "Livelli di log opzionali per connettore e per plugin. Usa default per ereditare le impostazioni globali di registrazione."
+        name: "Impostazioni avanzate di registrazione"
+        description: "Livelli di log opzionali per connettore e per plugin. Usa default per ereditare le impostazioni globali di log."
         fields:
           brand1:
             name: "Account veicolo 1"
@@ -132,21 +132,21 @@ configuration:
               log_level:
                 name: "Livello di log"
               api_log_level:
-                name: "Livello di log API"
+                name: "Livello di log dell'API"
           brand2:
             name: "Account veicolo 2"
             fields:
               log_level:
                 name: "Livello di log"
               api_log_level:
-                name: "Livello di log API"
+                name: "Livello di log dell'API"
           volvo:
             name: "Connettore Volvo"
             fields:
               log_level:
                 name: "Livello di log"
               api_log_level:
-                name: "Livello di log API"
+                name: "Livello di log dell'API"
           mqtt:
             name: "Plugin MQTT"
             fields:

--- a/carconnectivity-addon/translations/nl.yaml
+++ b/carconnectivity-addon/translations/nl.yaml
@@ -123,7 +123,7 @@ configuration:
         name: "API-niveau"
         description: "Logboekniveau specifiek voor API's."
       advanced:
-        name: "Geavanceerde logboek-overschrijvingen"
+        name: "Geavanceerde instellingen voor logboekregistratie"
         description: "Optionele logboekniveaus per connector en per plugin. Gebruik default om de globale logboekinstellingen over te nemen."
         fields:
           brand1:

--- a/carconnectivity-addon/translations/nl.yaml
+++ b/carconnectivity-addon/translations/nl.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "API-niveau"
         description: "Logboekniveau specifiek voor API's."
+      advanced:
+        name: "Geavanceerde logboek-overschrijvingen"
+        description: "Optionele logboekniveaus per connector en per plugin. Gebruik default om de globale logboekinstellingen over te nemen."
+        fields:
+          brand1:
+            name: "Voertuigaccount 1"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+              api_log_level:
+                name: "API-logboekniveau"
+          brand2:
+            name: "Voertuigaccount 2"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+              api_log_level:
+                name: "API-logboekniveau"
+          volvo:
+            name: "Volvo-connector"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+              api_log_level:
+                name: "API-logboekniveau"
+          mqtt:
+            name: "MQTT-plugin"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+          webui:
+            name: "Webinterface-plugin"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+          abrp:
+            name: "ABRP-plugin"
+            fields:
+              log_level:
+                name: "Logboekniveau"
+          mqtt_homeassistant:
+            name: "MQTT Home Assistant-plugin"
+            fields:
+              log_level:
+                name: "Logboekniveau"
 
   # --- EXPERT OPTIE ---
   expert:

--- a/carconnectivity-addon/translations/no.yaml
+++ b/carconnectivity-addon/translations/no.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "API-nivå"
         description: "Loggnivå spesifikk for API-er."
+      advanced:
+        name: "Avanserte overstyringer for logging"
+        description: "Valgfrie loggnivåer per kobling og per plugin. Bruk default for å arve de globale logginnstillingene."
+        fields:
+          brand1:
+            name: "Kjøretøykonto 1"
+            fields:
+              log_level:
+                name: "Loggnivå"
+              api_log_level:
+                name: "API-loggnivå"
+          brand2:
+            name: "Kjøretøykonto 2"
+            fields:
+              log_level:
+                name: "Loggnivå"
+              api_log_level:
+                name: "API-loggnivå"
+          volvo:
+            name: "Volvo-kobling"
+            fields:
+              log_level:
+                name: "Loggnivå"
+              api_log_level:
+                name: "API-loggnivå"
+          mqtt:
+            name: "MQTT-plugin"
+            fields:
+              log_level:
+                name: "Loggnivå"
+          webui:
+            name: "Webgrensesnitt-plugin"
+            fields:
+              log_level:
+                name: "Loggnivå"
+          abrp:
+            name: "ABRP-plugin"
+            fields:
+              log_level:
+                name: "Loggnivå"
+          mqtt_homeassistant:
+            name: "MQTT Home Assistant-plugin"
+            fields:
+              log_level:
+                name: "Loggnivå"
 
   # --- EXPERT ALTERNATIV ---
   expert:

--- a/carconnectivity-addon/translations/no.yaml
+++ b/carconnectivity-addon/translations/no.yaml
@@ -123,7 +123,7 @@ configuration:
         name: "API-nivå"
         description: "Loggnivå spesifikk for API-er."
       advanced:
-        name: "Avanserte overstyringer for logging"
+        name: "Avanserte logginnstillinger"
         description: "Valgfrie loggnivåer per kobling og per plugin. Bruk default for å arve de globale logginnstillingene."
         fields:
           brand1:

--- a/carconnectivity-addon/translations/pl.yaml
+++ b/carconnectivity-addon/translations/pl.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "Poziom API"
         description: "Poziom logowania specyficzny dla API."
+      advanced:
+        name: "Zaawansowane nadpisania rejestrowania"
+        description: "Opcjonalne poziomy logowania dla poszczególnych konektorów i pluginów. Użyj default, aby odziedziczyć globalne ustawienia logowania."
+        fields:
+          brand1:
+            name: "Konto pojazdu 1"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+              api_log_level:
+                name: "Poziom logowania API"
+          brand2:
+            name: "Konto pojazdu 2"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+              api_log_level:
+                name: "Poziom logowania API"
+          volvo:
+            name: "Konektor Volvo"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+              api_log_level:
+                name: "Poziom logowania API"
+          mqtt:
+            name: "Plugin MQTT"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+          webui:
+            name: "Plugin interfejsu WWW"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+          abrp:
+            name: "Plugin ABRP"
+            fields:
+              log_level:
+                name: "Poziom logowania"
+          mqtt_homeassistant:
+            name: "Plugin MQTT Home Assistant"
+            fields:
+              log_level:
+                name: "Poziom logowania"
 
   # --- OPCJA EXPERT ---
   expert:

--- a/carconnectivity-addon/translations/pl.yaml
+++ b/carconnectivity-addon/translations/pl.yaml
@@ -123,50 +123,50 @@ configuration:
         name: "Poziom API"
         description: "Poziom logowania specyficzny dla API."
       advanced:
-        name: "Zaawansowane nadpisania rejestrowania"
-        description: "Opcjonalne poziomy logowania dla poszczególnych konektorów i pluginów. Użyj default, aby odziedziczyć globalne ustawienia logowania."
+        name: "Zaawansowane opcje nadpisywania logów"
+        description: "Opcjonalne poziomy logowania dla poszczególnych konektorów i pluginów. Użyj default, aby zastosować globalne ustawienia logowania."
         fields:
           brand1:
             name: "Konto pojazdu 1"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
               api_log_level:
                 name: "Poziom logowania API"
           brand2:
             name: "Konto pojazdu 2"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
               api_log_level:
                 name: "Poziom logowania API"
           volvo:
             name: "Konektor Volvo"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
               api_log_level:
                 name: "Poziom logowania API"
           mqtt:
             name: "Plugin MQTT"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
           webui:
             name: "Plugin interfejsu WWW"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
           abrp:
             name: "Plugin ABRP"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
           mqtt_homeassistant:
             name: "Plugin MQTT Home Assistant"
             fields:
               log_level:
-                name: "Poziom logowania"
+                name: "Poziom dziennika"
 
   # --- OPCJA EXPERT ---
   expert:

--- a/carconnectivity-addon/translations/pt.yaml
+++ b/carconnectivity-addon/translations/pt.yaml
@@ -124,7 +124,7 @@ configuration:
         description: "Nível de registo específico para as APIs."
       advanced:
         name: "Substituições avançadas de registo"
-        description: "Níveis de registo opcionais por conector e por plugin. Use default para herdar as definições globais de registo."
+        description: "Níveis de registo opcionais por conector e por plugin. Utilize default para herdar as definições globais de registo."
         fields:
           brand1:
             name: "Conta de veículo 1"

--- a/carconnectivity-addon/translations/pt.yaml
+++ b/carconnectivity-addon/translations/pt.yaml
@@ -122,6 +122,51 @@ configuration:
       api_level:
         name: "Nível das APIs"
         description: "Nível de registo específico para as APIs."
+      advanced:
+        name: "Substituições avançadas de registo"
+        description: "Níveis de registo opcionais por conector e por plugin. Use default para herdar as definições globais de registo."
+        fields:
+          brand1:
+            name: "Conta de veículo 1"
+            fields:
+              log_level:
+                name: "Nível de registo"
+              api_log_level:
+                name: "Nível de registo da API"
+          brand2:
+            name: "Conta de veículo 2"
+            fields:
+              log_level:
+                name: "Nível de registo"
+              api_log_level:
+                name: "Nível de registo da API"
+          volvo:
+            name: "Conector Volvo"
+            fields:
+              log_level:
+                name: "Nível de registo"
+              api_log_level:
+                name: "Nível de registo da API"
+          mqtt:
+            name: "Plugin MQTT"
+            fields:
+              log_level:
+                name: "Nível de registo"
+          webui:
+            name: "Plugin da interface web"
+            fields:
+              log_level:
+                name: "Nível de registo"
+          abrp:
+            name: "Plugin ABRP"
+            fields:
+              log_level:
+                name: "Nível de registo"
+          mqtt_homeassistant:
+            name: "Plugin MQTT Home Assistant"
+            fields:
+              log_level:
+                name: "Nível de registo"
 
   # --- OPÇÃO EXPERT ---
   expert:


### PR DESCRIPTION
## Summary

Adds optional per-component logging overrides to the stable add-on configuration.

Users can now keep the global add-on log level at `info` while enabling `debug` only for a specific configured connector or plugin.

## What changed

- Added `logs.advanced` options for:
  - `brand1`
  - `brand2`
  - `volvo`
  - `mqtt`
  - `webui`
  - `abrp`
  - `mqtt_homeassistant`
- Added connector-level `log_level` and `api_log_level` rendering in `carconnectivity.UI.json`
- Added plugin-level `log_level` overrides
- `default` inherits the existing global setting and is not written to the generated JSON
- Added documentation and translated UI labels

## Example

```yaml
logs:
  level: info
  api_level: info
  advanced:
    brand1:
      log_level: debug
      api_log_level: debug
```

This enables debug logging only for the first configured vehicle account while the rest of the add-on continues to use the global `info` level.

## Validation

- Rendered the template with Home Assistant `tempio`
- Verified legacy configs without `logs.advanced` still fall back to global log settings
- Verified `default` is not written to generated JSON
- Validated `config.yaml`
- Validated all translation YAML files
- Verified all translation files have matching i18n key structure
