### PR TITLE
docs: sync README translations with the English reference

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -33,7 +33,7 @@ Ich nutze einfach [Das ausgezeichnete Repository von Till.](https://github.com/t
 
 Sein Repository ist auch als Docker -Bild verfügbar. Also, wenn Sie `Home Assistant`als eigenständiges`docker` verwenden, können Sie es auch direkt verwenden.
 
-**⚠️Das Projekt befindet sich noch in der Entwicklung,`reverse engineering`der API**
+**⚠️Das Projekt befindet sich noch in der Entwicklung, `reverse engineering` der API muss noch abgeschlossen und die Kommunikation mit MQTT/Home Assistant angepasst werden.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 VAG-API-Sperrung : Volkswagen / Seat / Cupra (Mai 2026)
@@ -70,12 +70,12 @@ Wählen Sie den Hersteller aus, der Ihrem Fahrzeug aus den unterstützten Marken
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(Land wird automatisch durch Ihre Home Assistant-Ländereinstellung festgelegt — standardmäßig us, oder ca, wenn Ihr HA für Kanada konfiguriert ist)*
+- `Volkswagen North America` *(Land wird automatisch durch Ihre Home Assistant-Ländereinstellung festgelegt — standardmäßig `us`, oder `ca`, wenn Ihr HA für Kanada konfiguriert ist)*
 - `EU Data Act` *(gemeinsamer schreibgeschützter Konnektor, der die gesperrten Konnektoren Seat / Cupra / Volkswagen (Europa) ersetzt)*
 
 Wenn Sie mehrere Fahrzeuge aus verschiedenen Marken besitzen, können Sie mehrere Abschnitte konfigurieren.
 
-### 2.. Verbinden Sie sich mit den Online -Diensten des Herstellers
+### 2. Verbinden Sie sich mit den Online -Diensten des Herstellers
 
 Jeder Autohersteller bietet einen Online -Service an, mit dem Sie auf die Daten Ihres Fahrzeugs remote zugreifen können. Um eine Verbindung herzustellen, müssen Sie Ihre Anmeldeinformationen angeben.
 
@@ -103,14 +103,14 @@ Dieser **schreibgeschützte** Konnektor ersetzt die Konnektoren Seat / Cupra / V
 
 Für`Volvo`:
 
--   `API Key primary`: Volvo API primary key.
+-   `API Key primary`: Volvo API Primärschlüssel.
 -   `API Key secondary`: Volvo API Sekundärschlüssel.
--   `Vehicule Token`: Access token for the vehicule.
+-   `Vehicule Token`: Zugang zu Token für das Fahrzeug.
 -   `Vehicule Location Token`: Zugang zu Token für den Standortendpunkt.
 -   `Refresh Interval`: Definiert, wie oft (in Sekunden) die Daten des Fahrzeugs aktualisiert werden.
 -   `Warning:`Das zu häufiges Einstellen einer Aktualisierungsrate kann die vom Hersteller auferlegten API -Anforderungsgrenzen überschreiten, was zu temporären Zugriffsbeschränkungen führt.
 
-### 3.. MQTT -Konfiguration (obligatorisch)
+### 3. MQTT -Konfiguration (obligatorisch)
 
 Sie müssen `MQTT` verwenden um Fahrzeugdaten an `Home Assistant` zu senden. Konfigurieren Sie diese Einstellungen:
 
@@ -122,7 +122,7 @@ Sie müssen `MQTT` verwenden um Fahrzeugdaten an `Home Assistant` zu senden. Kon
 
 ### 4.`WEBUI`
 
-Sie können auf die oberfläche con `Carconnectivity` zugreifen. Die ursprüngliche Schnittstelle.
+Sie können auf die oberfläche von `Carconnectivity` zugreifen. Die ursprüngliche Schnittstelle.
 Sie können Ihre eigenen Zugriffsanmeldeinformationen definieren:
 
 -   `Username`: admin
@@ -194,9 +194,9 @@ In der offiziellen Dokumentation von Carconnectivity finden Sie die Liste der un
 ## Best Practices
 
 -   **Füllen Sie nur die Einstellungen für die Fahrzeugmarken aus, die Sie besitzen.**
--   \***\*Teilen Sie Ihre Login -Anmeldeinformationen nicht. \*\***
+-   **Teilen Sie Ihre Login -Anmeldeinformationen nicht.**
 -   **Passen Sie das Aktualisierungsintervall an, um die Überschreitung von API -Anforderungsgrenzen zu vermeiden. Denken Sie daran, die Grenze scheint ungefähr 1000 REQ/Day zu sein.**
--   **Verwenden Sie das "Debug" -Protokollierungsebene nur bei Problembehebungsproblemen.**\`\*\*
+-   **Verwenden Sie das "Debug" -Protokollierungsebene nur bei Problembehebungsproblemen.**
 
 * * *
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,8 @@
-![Supports aarch64 Architecture][aarch64-shield]![Supports amd64 Architecture][amd64-shield][![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+[![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)
+[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 
@@ -24,12 +28,12 @@
 
 ## Introducción
 
-`CarConnectivity-Addon`Le permite conectarse y recuperar información sobre su vehículo de los servicios en línea de los fabricantes compatibles. Esta guía explica cómo configurar correctamente el módulo.
-Simplemente estoy empaquetando[El trabajo (excelente) realizado por Till.](https://github.com/tillsteinbach/CarConnectivity)
+`CarConnectivity-Addon` Le permite conectarse y recuperar información sobre su vehículo de los servicios en línea de los fabricantes compatibles. Esta guía explica cómo configurar correctamente el módulo.
+Simplemente estoy empaquetando [El trabajo (excelente) realizado por Till.](https://github.com/tillsteinbach/CarConnectivity)
 
-Su trabajo también está disponible como imágenes de Docker. Entonces, si estás usando`Home Assistant`como independiente`docker`, también puedes usarlo directamente.
+Su trabajo también está disponible como imágenes de Docker. Entonces, si estás usando `Home Assistant` como independiente `docker`, también puedes usarlo directamente.
 
-**⚠️ El proyecto todavía está en desarrollo,`reverse engineering`de la API que se completará y la comunicación con MQTT/Asistente de inicio para ser adaptado.**
+**⚠️ El proyecto todavía está en desarrollo, `reverse engineering` de la API que se completará y la comunicación con MQTT/Asistente de inicio para ser adaptado.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 Bloqueo de la API de VAG : Volkswagen / Seat / Cupra (mayo de 2026)
@@ -66,7 +70,7 @@ Elija el fabricante correspondiente a su vehículo de las marcas compatibles:
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(país configurado automáticamente desde su ajuste de país en Home Assistant — uspor defecto,ca si su HA está configurado para Canadá)*
+- `Volkswagen North America` *(país configurado automáticamente desde su ajuste de país en Home Assistant — `us` por defecto, `ca` si su HA está configurado para Canadá)*
 - `EU Data Act` *(conector común de solo lectura que reemplaza los conectores bloqueados Seat / Cupra / Volkswagen (Europa))*
 
 Si posee múltiples vehículos de diferentes marcas, puede configurar varias secciones.
@@ -84,7 +88,7 @@ Para `Skoda`, `Audi`, `Volkswagen North America` y `Tronity`:
 -   `Password`: La contraseña para su cuenta de fabricante.
 -   `PIN Code`: Un código de 4 dígitos requerido para el acceso remoto a ciertas características del vehículo.
 -   `Refresh Interval`: Define con qué frecuencia (en segundos) se actualizan los datos del vehículo.
--   `Warning:`Establecer una velocidad de actualización con demasiada frecuencia puede exceder los límites de solicitud de API impuestos por el fabricante, lo que resulta en restricciones de acceso temporales.
+-   `Warning:` Establecer una velocidad de actualización con demasiada frecuencia puede exceder los límites de solicitud de API impuestos por el fabricante, lo que resulta en restricciones de acceso temporales.
 
 ⚠️ Puede usar 2 cuentas para 2 marcas diferentes o 2 autos de una misma marca que no están vinculadas a la misma cuenta.
 
@@ -97,28 +101,28 @@ Este conector **de solo lectura** reemplaza los conectores Seat / Cupra / Volksw
 
 > ⚠️ **Paso obligatorio (de lo contrario el conector no recibe nada).** Habilite primero la entrega de datos en el portal: regístrese en **[eu-data-act.drivesomethinggreater.com](https://eu-data-act.drivesomethinggreater.com/)** con la **misma cuenta** que la aplicación oficial de su marca, luego solicite **todos los clústeres de datos**, un **intervalo de 15 minutos** y una **duración ilimitada**. Los primeros datos pueden tardar **varias horas** en aparecer. El conector solo **descarga** lo que el portal ya ha producido: mientras no haya ningún archivo disponible del lado de EU Data Act, no puede **leer nada**, incluso con credenciales correctas (esto puede parecer un rechazo de credenciales).
 
-Para`Volvo`:
+Para `Volvo`:
 
--   `API Key primary`: Volvo API primary key.
+-   `API Key primary`: Clave primaria de la API de Volvo.
 -   `API Key secondary`: Clave secundaria Volvo API.
 -   `Vehicule Token`: Token de acceso para el vehículo.
 -   `Vehicule Location Token`: Token de acceso para el punto final de ubicación.
 -   `Refresh Interval`: Define con qué frecuencia (en segundos) se actualizan los datos del vehículo.
--   `Warning:`Establecer una velocidad de actualización con demasiada frecuencia puede exceder los límites de solicitud de API impuestos por el fabricante, lo que resulta en restricciones de acceso temporales.
+-   `Warning:` Establecer una velocidad de actualización con demasiada frecuencia puede exceder los límites de solicitud de API impuestos por el fabricante, lo que resulta en restricciones de acceso temporales.
 
 ### 3. Configuración MQTT (obligatoria)
 
-Necesitas usar`MQTT`para enviar datos del vehículo a`Home Assistant`, Configure estos ajustes:
+Necesitas usar `MQTT` para enviar datos del vehículo a `Home Assistant`, Configure estos ajustes:
 
 -   `Username`: MQTT Broker Iniciar sesión
 -   `Password`: Contraseña de mqtt corredor
 -   `Broker Address`: IP o nombre de dominio del servidor MQTT
 
-⚠️ si aún no estás usando mqtt en`Home Assistant`, puede agregar, por ejemplo,[`Mosquito Addon`Y`MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
+⚠️ si aún no estás usando mqtt en `Home Assistant`, puede agregar, por ejemplo, [`Mosquito Addon` Y `MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
 
 ### 4.`WEBUI`
 
-Puedes acceder al`Carconnectivity`La interfaz original del uso directamente desde`Home Assistant`.
+Puedes acceder al `Carconnectivity` La interfaz original del uso directamente desde `Home Assistant`.
 Puede definir sus propias credenciales de acceso:
 
 -   `Username`: admin
@@ -156,15 +160,17 @@ Para recuperar su token, vaya a su vehículo en un mejor planeador de rutina, se
 
 Cada línea debe seguir este formato:
 
--   `vin`: Este campo representa el**Número de identificación del vehículo**(Vin). Es exclusivo de cada vehículo y contiene 17 caracteres alfanuméricos.
--   `token`: Este campo representa un**token de autenticación**específico de cada vehículo. ABRP genera este token cuando conecta su vehículo a la plataforma.
+-   `vin`: Este campo representa el **Número de identificación del vehículo** (Vin). Es exclusivo de cada vehículo y contiene 17 caracteres alfanuméricos.
+-   `token`: Este campo representa un **token de autenticación** específico de cada vehículo. ABRP genera este token cuando conecta su vehículo a la plataforma.
 
 ##### Ejemplo de una configuración válida:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Modo experto
 
@@ -190,9 +196,9 @@ Consulte la documentación oficial de la carconectividad para obtener la lista d
 ## Mejores prácticas
 
 -   **Solo complete la configuración de las marcas de vehículos que posee.**
--   \***\*No comparta sus credenciales de inicio de sesión. \*\***
+-   **No comparta sus credenciales de inicio de sesión.**
 -   **Ajuste el intervalo de actualización para evitar exceder los límites de solicitud de API. Recuerde que el límite parece ser de aproximadamente 1000 req/día.**
--   **Use el nivel de registro de "depuración" solo cuando resuelva problemas.**\`\*\*
+-   **Use el nivel de registro de "Debug" solo cuando resuelva problemas.**
 
 * * *
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -33,7 +33,7 @@ Je ne fais simplement qu'integrer [Le travail (excellent) fait par Till.](https:
 
 Son travail est également disponible sous forme d'images Docker. Donc si vous utilisez `Home Assistant` en tant que autonome`docker`, vous pouvez également l'utiliser directement.
 
-**⚠️ Le projet est toujours en cours de développement, le `reverse engineering` de l'API à terminer et la communication avec MQTT / Assistant à domicile à adapter.**
+**⚠️ Le projet est toujours en cours de développement, le `reverse engineering` de l'API à terminer et la communication avec MQTT / Assistant à domicile à adapter.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 Blocage de l'API VAG : Volkswagen / Seat / Cupra (mai 2026)
@@ -106,7 +106,7 @@ Pour`Volvo`:
 -   `API Key primary`: Clé primaire de l'API Volvo.
 -   `API Key secondary`: Clé secondaire de l'API Volvo.
 -   `Vehicule Token`: Jeton d'accès pour le véhicule.
--   `Vehicule Location Token`: Access token for the location endpoint.
+-   `Vehicule Location Token`: Jeton d'accès pour le point de terminaison de localisation.
 -   `Refresh Interval`: Définit la fréquence à la mise à jour des données du véhicule.
 -   `Warning:`La définition d'un taux de rafraîchissement trop fréquemment peut dépasser les limites de demande de l'API imposées par le fabricant, ce qui entraîne des restrictions d'accès temporaires.
 
@@ -196,9 +196,9 @@ Reportez-vous à la documentation officielle de `CarConnectivity` pour la liste 
 ## Bonnes pratiques
 
 -   **Remplissez uniquement les paramètres des marques de véhicules que vous possédez.**
--   \***\* Ne partagez pas vos informations d'identification de connexion. \*\***
+-   **Ne partagez pas vos informations d'identification de connexion.**
 -   **Ajustez l'intervalle de rafraîchissement pour éviter de dépasser les limites de demande d'API. N'oubliez pas que la limite semble être d'environ 1000 req / jour.**
--   **Utilisez le niveau de journalisation "de débogage" uniquement lors du dépannage des problèmes.**\`\*\*
+-   **Utilisez le niveau de journalisation "Debug" uniquement lors du dépannage des problèmes.**
 
 * * *
 

--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,8 @@
-![Supports aarch64 Architecture][aarch64-shield]![Supports amd64 Architecture][amd64-shield][![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+[![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)
+[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 
@@ -24,10 +28,10 @@
 
 ## Introduzione
 
-`CarConnectivity-Addon`Ti consente di connettere e recuperare informazioni sul veicolo dai servizi online dei produttori compatibili. Questa guida spiega come configurare correttamente il modulo.
+`CarConnectivity-Addon` Ti consente di connettere e recuperare informazioni sul veicolo dai servizi online dei produttori compatibili. Questa guida spiega come configurare correttamente il modulo.
 Sto semplicemente confezionando[Il lavoro (eccellente) svolto da Till.](https://github.com/tillsteinbach/CarConnectivity)
 
-Il suo lavoro è disponibile anche come Docker Images. Quindi se stai usando`Home Assistant`come autonomo`docker`, puoi usarlo direttamente anche tu.
+Il suo lavoro è disponibile anche come Docker Images. Quindi se stai usando `Home Assistant` come autonomo `docker`, puoi usarlo direttamente anche tu.
 
 **⚠️ Il progetto è ancora in fase di sviluppo,`reverse engineering`dell'API da completare e comunicare con MQTT/Assistente di casa da adattare.**
 
@@ -48,7 +52,7 @@ Il suo lavoro è disponibile anche come Docker Images. Quindi se stai usando`Hom
 
 ## Add repository
 
-[![\`Addon Home Assistant\`](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/addon-ha.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FPulpyyyy%2Fcarconnectivity-addon)
+[![`Addon Home Assistant`](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/addon-ha.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FPulpyyyy%2Fcarconnectivity-addon)
 
 ![image](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/img/mqtt_device.png)
 
@@ -66,7 +70,7 @@ Scegli il produttore corrispondente al tuo veicolo dai marchi supportati:
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(paese impostato automaticamente dalle impostazioni del paese di Home Assistant — usper impostazione predefinita,ca se il tuo HA è configurato per il Canada)*
+- `Volkswagen North America` *(paese impostato automaticamente dalle impostazioni del paese di Home Assistant — `us` per impostazione predefinita, `ca` se il tuo HA è configurato per il Canada)*
 - `EU Data Act` *(connettore comune di sola lettura che sostituisce i connettori Seat / Cupra / Volkswagen (Europa) bloccati)*
 
 Se possiedi più veicoli di marchi diversi, è possibile configurare più sezioni.
@@ -81,7 +85,7 @@ Per `Skoda`, `Audi`, `Volkswagen North America` e `Tronity` :
 
 -   `Brand`: Il marchio del produttore.
 -   `Username`: L'indirizzo e -mail utilizzato per accedere al servizio del produttore.
--   `Password`: The password for your manufacturer account.
+-   `Password`: La password del tuo account del produttore.
 -   `PIN Code`: Un codice a 4 cifre richiesto per l'accesso remoto a determinate funzionalità del veicolo.
 -   `Refresh Interval`: Definisce la frequenza con cui (in secondi) i dati del veicolo vengono aggiornati.
 -   `Warning:`L'impostazione di una frequenza di aggiornamento troppo frequentemente può superare i limiti di richiesta API imposti dal produttore, con conseguenti restrizioni di accesso temporanee.
@@ -108,17 +112,17 @@ Per`Volvo`:
 
 ### 3. Configurazione MQTT (obbligatoria)
 
-Devi usare`MQTT`Per inviare i dati del veicolo a`Home Assistant`, Configura queste impostazioni:
+Devi usare `MQTT` Per inviare i dati del veicolo a `Home Assistant`, Configura queste impostazioni:
 
 -   `Username`: Accesso al broker MQTT
 -   `Password`: Password del broker MQTT
 -   `Broker Address`: IP o nome di dominio del server MQTT
 
-⚠️ Se non stai già usando MQTT`Home Assistant`, puoi aggiungere, ad esempio,[`Mosquito Addon`E`MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
+⚠️ Se non stai già usando MQTT `Home Assistant`, puoi aggiungere, ad esempio, [`Mosquito Addon` E `MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
 
 ### 4.`WEBUI`
 
-Puoi accedere al`Carconnectivity`L'interfaccia originale dall'uso direttamente da`Home Assistant`.
+Puoi accedere al `Carconnectivity` L'interfaccia originale dall'uso direttamente da `Home Assistant`.
 Puoi definire le tue credenziali di accesso:
 
 -   `Username`: admin
@@ -144,7 +148,7 @@ Definire la quantità di informazioni registrate nei registri:
 -   `Error`: Visualizza solo i messaggi di errore.
 -   `Debug`: Visualizza ulteriori dettagli utili per la risoluzione dei problemi.
 
-### 7.`ABRP - A Better Routeplanner`
+### 7. `ABRP - A Better Routeplanner`
 
 Per ogni veicolo che si desidera connettere ad ABRP (un percorso migliore), è necessario fornire un identificatore univoco per ciascun veicolo (`vin`) così come un token di autenticazione (`token`). Queste coppie di valori consentono di stabilire una corrispondenza tra il veicolo e il suo token nel sistema ABRP.
 
@@ -154,21 +158,23 @@ Per recuperare il token, visitare il veicolo su un percorso migliore, selezionar
 
 #### Formato di configurazione
 
-Each line should follow this format:
+Ogni riga deve seguire questo formato:
 
--   `vin`: This field represents the **Numero di identificazione del veicolo**(Vin). È unico per ogni veicolo e contiene 17 caratteri alfanumerici.
+-   `vin`: Questo campo rappresenta il **Numero di identificazione del veicolo** (VIN). È unico per ogni veicolo e contiene 17 caratteri alfanumerici.
 -   `token`: Questo campo rappresenta un**token di autenticazione**specifico per ogni veicolo. Questo token è generato da ABRP quando si collega il veicolo alla piattaforma.
 
 ##### Esempio di una configurazione valida:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Modalità esperta
 
-Expert Mode enables the use of all native Carconnectivity functions, including those not available through the graphical interface—as long as the corresponding functions are supported by the add-on binaries.
+La modalità Expert consente di utilizzare tutte le funzioni native di Carconnectivity, comprese quelle non disponibili tramite l'interfaccia grafica, purché le funzioni corrispondenti siano supportate dai binari dell'add-on.
 
 ⚠️ ATTENZIONE:
 Questa modalità disabilita tutti i controlli di convalida e sicurezza dei contenuti. Di conseguenza, anche un piccolo errore (come una sintassi JSON non valida) può impedire l'avvio corretto del componente aggiuntivo.
@@ -190,9 +196,9 @@ Fare riferimento alla documentazione ufficiale di Carconnettività per l'elenco 
 ## Best practice
 
 -   **Compila solo le impostazioni per i marchi del veicolo che possiedi.**
--   \***\*Non condividere le credenziali di accesso. \*\***
+-   **Non condividere le credenziali di accesso.**
 -   **Regolare l'intervallo di aggiornamento per evitare il superamento dei limiti di richiesta API. Ricorda il limite sembra essere circa 1000 req/giorno.**
--   **Utilizzare il livello di registrazione "debug" solo durante la risoluzione dei problemi.**\`\*\*
+-   **Utilizzare il livello di registrazione "Debug" solo durante la risoluzione dei problemi.**
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 [![Spanish](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/ES.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.es.md)
 [![Polish](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/PL.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.pl.md)
 [![Portuguese](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/PT.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.pt.md)
- [![Norwegian](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/NO.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.no.md)
+[![Norwegian](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/NO.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.no.md)
+[![Dutch](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/NL.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.nl.md)
 [![English](https://raw.githubusercontent.com/Pulpyyyy/carconnectivity-addon/refs/heads/main/.github/img/US.svg)](https://github.com/Pulpyyyy/carconnectivity-addon/blob/main/README.md)
 
 
@@ -180,9 +181,9 @@ Refer to the official Carconnectivity documentation for the list of supported fu
 
 ## Best Practices
 - **Only fill in the settings for the vehicle brands you own.**
-- ****Do not share your login credentials.****
+- **Do not share your login credentials.**
 - **Adjust the refresh interval to avoid exceeding API request limits. Remember limit seems to be about 1000 req/day.**
-- **Use the "Debug" logging level only when troubleshooting issues.**`**
+- **Use the "Debug" logging level only when troubleshooting issues.**
 
 ---
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,4 +1,8 @@
-![Supports aarch64 Architecture][aarch64-shield]![Supports amd64 Architecture][amd64-shield][![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+[![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)
+[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 
@@ -29,7 +33,7 @@ Ik ben gewoon een verpakking[Het werk (uitstekend) gedaan door tot.](https://git
 
 Zijn werk is ook beschikbaar als Docker -afbeeldingen. Dus als je gebruikt`Home Assistant`Als stand-alone`docker`, u kunt het ook direct gebruiken.
 
-**⚠️Het project is nog in ontwikkeling,`reverse engineering` of the api to be completed and communication with MQTT/Home assistant to be adapted.⚠️**
+**⚠️Het project is nog in ontwikkeling,`reverse engineering` van de api moet nog worden voltooid en de communicatie met MQTT/Home Assistant moet nog worden aangepast.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 VAG-API-blokkering : Volkswagen / Seat / Cupra (mei 2026)
@@ -54,7 +58,7 @@ Zijn werk is ook beschikbaar als Docker -afbeeldingen. Dus als je gebruikt`Home 
 
 ## Algemene configuratie
 
-Only fill in the settings for the brands of vehicles you own. **Laat alle andere velden leeg.**
+Vul alleen de instellingen in voor de merken van voertuigen die u bezit. **Laat alle andere velden leeg.**
 
 ### 1. Selecteer uw voertuigmerk
 
@@ -66,7 +70,7 @@ Kies de fabrikant die overeenkomt met uw voertuig uit de ondersteunde merken:
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(land automatisch ingesteld via de landinstelling van uw Home Assistant — standaard us, ca als uw HA is geconfigureerd voor Canada)*
+- `Volkswagen North America` *(land automatisch ingesteld via de landinstelling van uw Home Assistant — standaard `us`, `ca` als uw HA is geconfigureerd voor Canada)*
 - `EU Data Act` *(gemeenschappelijke alleen-lezen connector die de geblokkeerde connectoren Seat / Cupra / Volkswagen (Europa) vervangt)*
 
 Als u meerdere voertuigen van verschillende merken bezit, kunt u meerdere secties configureren.
@@ -161,10 +165,12 @@ Elke regel moet dit formaat volgen:
 
 ##### Voorbeeld van een geldige configuratie:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Deskundige modus
 
@@ -190,9 +196,9 @@ Raadpleeg de officiële carconnectiviteitsdocumentatie voor de lijst met onderst
 ## Best practices
 
 -   **Vul alleen de instellingen in voor de voertuigmerken die u bezit.**
--   \***\*Deel uw inloggegevens niet. \*\***
+-   **Deel uw inloggegevens niet.**
 -   **Pas het vernieuwingsinterval aan om te voorkomen dat API -aanvraaglimieten worden overschreden. Onthoud dat de limiet ongeveer 1000 req/dag lijkt te zijn.**
--   **Gebruik het "foutopsporingsniveau" alleen bij problemen met het oplossen van problemen.**\`\*\*
+-   **Gebruik het logniveau "Debug" alleen bij het oplossen van problemen.**
 
 * * *
 

--- a/README.no.md
+++ b/README.no.md
@@ -1,4 +1,8 @@
-![Supports aarch64 Architecture][aarch64-shield]![Supports amd64 Architecture][amd64-shield][![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+[![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)
+[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 
@@ -24,12 +28,12 @@
 
 ## Introduksjon
 
-`CarConnectivity-Addon`Lar deg koble til og hente informasjon om kjøretøyet ditt fra kompatible produsenters online tjenester. Denne guiden forklarer hvordan du konfigurerer modulen riktig.
+`CarConnectivity-Addon` Lar deg koble til og hente informasjon om kjøretøyet ditt fra kompatible produsenters online tjenester. Denne guiden forklarer hvordan du konfigurerer modulen riktig.
 Jeg pakker ganske enkelt[Arbeidet (utmerket) gjort av Till.](https://github.com/tillsteinbach/CarConnectivity)
 
-Hans arbeid er også tilgjengelig som Docker -bilder. Så hvis du bruker`Home Assistant`som en frittstående`docker`, kan du også bruke den direkte.
+Hans arbeid er også tilgjengelig som Docker -bilder. Så hvis du bruker `Home Assistant` som en frittstående `docker`, kan du også bruke den direkte.
 
-**⚠ Prosjektet er fremdeles under utvikling,`reverse engineering`av API som skal fullføres og kommunikasjon med MQTT/Home Assistant som skal tilpasses.⚠**
+**⚠️ Prosjektet er fremdeles under utvikling,`reverse engineering`av API som skal fullføres og kommunikasjon med MQTT/Home Assistant som skal tilpasses.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 VAG-API-blokkering : Volkswagen / Seat / Cupra (mai 2026)
@@ -66,7 +70,7 @@ Velg produsenten som tilsvarer kjøretøyet ditt fra de støttede merkene:
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(land settes automatisk fra din Home Assistant-landsinnstilling — ussom standard,ca hvis din HA er konfigurert for Canada)*
+- `Volkswagen North America` *(land settes automatisk fra din Home Assistant-landsinnstilling — `us` som standard, `ca` hvis din HA er konfigurert for Canada)*
 - `EU Data Act` *(felles skrivebeskyttet kobling som erstatter de blokkerte koblingene Seat / Cupra / Volkswagen (Europa))*
 
 Hvis du eier flere kjøretøyer fra forskjellige merker, kan du konfigurere flere seksjoner.
@@ -77,7 +81,7 @@ Hver bilprodusent leverer en online tjeneste som lar deg få tilgang til kjøret
 
 #### Nødvendig informasjon:
 
-Til`Skoda`,`Audi`,`Volkswagen North America`og`Tronity`:
+Til `Skoda`, `Audi`, `Volkswagen North America` og `Tronity`:
 
 -   `Brand`: Produsentens merkevare.
 -   `Username`: E -postadressen som ble brukt til å logge på produsentens tjeneste.
@@ -86,7 +90,7 @@ Til`Skoda`,`Audi`,`Volkswagen North America`og`Tronity`:
 -   `Refresh Interval`: Definerer hvor ofte (på sekunder) kjøretøyets data blir oppdatert.
 -   `Warning:`Å sette en oppdateringsfrekvens for ofte kan overstige API -forespørselsgrensene pålagt av produsenten, noe som resulterer i midlertidige tilgangsbegrensninger.
 
-⚠ Du kan bruke 2 kontoer for 2 forskjellige merker eller 2 biler av samme merke som ikke er koblet til samme konto.
+⚠️ Du kan bruke 2 kontoer for 2 forskjellige merker eller 2 biler av samme merke som ikke er koblet til samme konto.
 
 Til `EU Data Act` (Seat, Cupra, Volkswagen Europa; skrivebeskyttet):
 
@@ -108,17 +112,17 @@ Til`Volvo`:
 
 ### 3. MQTT -konfigurasjon (obligatorisk)
 
-Du må bruke`MQTT`å sende kjøretøydata til`Home Assistant`, Konfigurer disse innstillingene:
+Du må bruke `MQTT` å sende kjøretøydata til `Home Assistant`, Konfigurer disse innstillingene:
 
 -   `Username`: MQTT Megler pålogging
 -   `Password`: MQTT Meglerpassord
 -   `Broker Address`: IP eller domenenavn på MQTT -serveren
 
-⚠️ If you're not already using MQTT on `Home Assistant`, kan du for eksempel legge til[`Mosquito Addon`et`MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
+⚠️ Hvis du ikke allerede bruker MQTT på `Home Assistant`, kan du for eksempel legge til[`Mosquito Addon`et`MQTT integration`](https://www.home-assistant.io/integrations/mqtt)
 
 ### 4.`WEBUI`
 
-Du kan få tilgang til`Carconnectivity`sitt originale grensesnitt fra å bruke direkte fra`Home Assistant`.
+Du kan få tilgang til `Carconnectivity` sitt originale grensesnitt fra å bruke direkte fra `Home Assistant`.
 Du kan definere din egen tilgangsopplysning:
 
 -   `Username`: admin
@@ -161,16 +165,18 @@ Hver linje skal følge dette formatet:
 
 ##### Eksempel på en gyldig konfigurasjon:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Ekspertmodus
 
 Ekspertmodus muliggjør bruk av alle innfødte carconnectivity-funksjoner, inkludert de som ikke er tilgjengelige gjennom det grafiske grensesnittet-så lenge de tilsvarende funksjonene støttes av tilleggsbokstene.
 
-⚠ Advarsel:
+⚠️ Advarsel:
 Denne modusen deaktiverer all innholdsvalidering og sikkerhetskontroller. Som et resultat kan til og med en liten feil (for eksempel en ugyldig JSON-syntaks) forhindre at tillegget lanseres riktig.
 
 Ekspertmodus er kun ment for avanserte brukere.
@@ -190,9 +196,9 @@ Se den offisielle carconnectivity -dokumentasjonen for listen over støttede fun
 ## Beste praksis
 
 -   **Bare fyll ut innstillingene for kjøretøymerkene du eier.**
--   \***\*Ikke del påloggingsinformasjonen din. \*\***
+-   **Ikke del påloggingsinformasjonen din.**
 -   **Juster oppdateringsintervallet for å unngå å overskride API -forespørselsgrenser. Husk at grensen ser ut til å være omtrent 1000 req/dag.**
--   **Bruk "feilsøking" -loggingsnivå bare når du feilsøker problemer.**\`\*\*
+-   **Bruk "Debug"-loggingsnivå bare når du feilsøker problemer.**
 
 * * *
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -161,10 +161,12 @@ Każda linia powinna postępować zgodnie z tym formatem:
 
 ##### Przykład prawidłowej konfiguracji:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Tryb ekspertów
 
@@ -190,9 +192,9 @@ W celu uzyskania listy obsługiwanych funkcji i oczekiwanych parametrów zapozna
 ## Najlepsze praktyki
 
 -   **Wypełnij tylko ustawienia posiadanych marek pojazdów.**
--   \***\*Nie udostępniaj swoich poświadczeń logowania. \*\***
+-   **Nie udostępniaj swoich poświadczeń logowania.**
 -   **Dostosuj interwał odświeżania, aby uniknąć przekroczenia limitów żądania API. Pamiętaj, że limit wydaje się być około 1000 wymagań/dzień.**
--   **Użyj poziomu rejestrowania „debugowania” tylko podczas problemów z rozwiązywaniem problemów.**\`\*\*
+-   **Użyj poziomu rejestrowania „Debug” tylko podczas rozwiązywania problemów.**
 
 * * *
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,4 +1,8 @@
-![Supports aarch64 Architecture][aarch64-shield]![Supports amd64 Architecture][amd64-shield][![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
+![Supports aarch64 Architecture][aarch64-shield]
+![Supports amd64 Architecture][amd64-shield]
+[![GitHub sourcecode](https://img.shields.io/badge/Source-GitHub-green)](https://github.com/Pulpyyyy/carconnectivity-addon/)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/releases/latest)
+[![GitHub issues](https://img.shields.io/github/issues/Pulpyyyy/carconnectivity-addon)](https://github.com/Pulpyyyy/carconnectivity-addon/issues)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 
@@ -29,7 +33,7 @@ Estou simplesmente embalando[O trabalho (excelente) feito por Till.](https://git
 
 Seu trabalho também está disponível como imagens do Docker. Então, se você está usando`Home Assistant`como um independente`docker`, você também pode usá -lo diretamente.
 
-**⚠️ O projeto ainda está em desenvolvimento,`reverse engineering`da API a ser concluída e comunicação com o MQTT/Home Assistant a ser adaptado.**
+**⚠️ O projeto ainda está em desenvolvimento,`reverse engineering`da API a ser concluída e comunicação com o MQTT/Home Assistant a ser adaptado.⚠️**
 
 > [!IMPORTANT]
 > ### 🚧 Bloqueio da API da VAG : Volkswagen / Seat / Cupra (maio de 2026)
@@ -66,7 +70,7 @@ Escolha o fabricante correspondente ao seu veículo das marcas suportadas:
 - `Tronity`
 - `Volvo`
 - `Audi`
-- `Volkswagen North America` *(país definido automaticamente pelas configurações de país do seu Home Assistant — uspor padrão,ca se o seu HA estiver configurado para o Canadá)*
+- `Volkswagen North America` *(país definido automaticamente pelas configurações de país do seu Home Assistant — `us` por padrão, `ca` se o seu HA estiver configurado para o Canadá)*
 - `EU Data Act` *(conector comum somente leitura que substitui os conectores Seat / Cupra / Volkswagen (Europa) bloqueados)*
 
 Se você possui vários veículos de diferentes marcas, poderá configurar várias seções.
@@ -118,7 +122,7 @@ Você precisa usar`MQTT`Para enviar dados do veículo para`Home Assistant`, defi
 
 ### 4.`WEBUI`
 
-You can access the `Carconnectivity`a interface original de usar diretamente de`Home Assistant`.
+Você pode acessar a interface original do `Carconnectivity` diretamente do `Home Assistant`.
 Você pode definir suas próprias credenciais de acesso:
 
 -   `Username`: admin
@@ -161,10 +165,12 @@ Cada linha deve seguir este formato:
 
 ##### Exemplo de uma configuração válida:
 
-    - vin: TMBLJ9NY8SF000000
-      token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
-    - vin: TMLLJ9NY23F000000
-      token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
+- vin: TMBLJ9NY8SF000000
+  token: 1623fdc3-4aaf-49f5-b51a-1e55435435da2
+- vin: TMLLJ9NY23F000000
+  token: 12afe123-59d4-8a3d-b9ef-29367de7f8749
+```
 
 ### 8. Modo de especialista
 
@@ -190,9 +196,9 @@ Consulte a documentação oficial da carconnectividade para obter a lista de fun
 ## Práticas recomendadas
 
 -   **Preencha apenas as configurações das marcas de veículos que você possui.**
--   \***\*Não compartilhe suas credenciais de login. \*\***
+-   **Não compartilhe suas credenciais de login.**
 -   **Ajuste o intervalo de atualização para evitar exceder os limites da solicitação da API. Lembre -se de que o limite parece ser cerca de 1000 req/dia.**
--   **Use o nível de registro "Debug" somente ao solucionar problemas.**\`\*\*
+-   **Use o nível de registro "Debug" somente ao solucionar problemas.**
 
 * * *
 


### PR DESCRIPTION
Fixes found by a full audit of the 8 translated READMEs against the English reference.

## English reference
- Add the missing Dutch guide link in the Translated guides list
- Fix malformed bold markdown in Best Practices (`****` and stray trailing ``` `** ```)

## All translations
- Translate leftover English passages (Volvo bullets, Expert Mode intro in Italian, MQTT tip in Norwegian, development warning in Dutch/German, WEBUI sentence in Portuguese, location token in French)
- Clean escaped asterisks in Best Practices so bold renders, keep the literal "Debug" level name
- Restore backticks around the `us` / `ca` country codes and the fused spacing around them (es, it, nl, no, pt)
- Restore the trailing warning emoji on the development notice (fr, es, pt, de)
- German: complete the truncated development warning, fix the `2..` / `3..` headings, fix a stray non-German word
- Convert the ABRP example to a fenced code block and put the header badges on separate lines (es, it, nl, no, pl, pt)
- Add missing spaces around inline code spans (es, it, no)

No wording, URL or technical value was changed beyond the items above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)