### PR TITLE
feat(configui): default country/language in the generated config

### DIFF
--- a/carconnectivity-addon-edge/rootfs/opt/configui/generator.py
+++ b/carconnectivity-addon-edge/rootfs/opt/configui/generator.py
@@ -8,9 +8,11 @@ preserved verbatim (passthrough).
 """
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from const import KINDS, SOURCE_EU_DATA_ACT, connector_for, resolve_source
+from migrate import inject_locale
 
 _DEFAULT_LOG = "info"
 _DEFAULT_API_LOG = "error"
@@ -102,7 +104,13 @@ def build_config(state: dict[str, Any]) -> dict[str, Any]:
     plugins.append({"type": "mqtt_homeassistant", "config": {"log_level": log_level}})
     plugins.extend(state.get("_passthrough_plugins") or [])
 
-    return {"carConnectivity": {"log_level": log_level, "connectors": connectors, "plugins": plugins}}
+    config = {"carConnectivity": {"log_level": log_level, "connectors": connectors, "plugins": plugins}}
+    # HA_COUNTRY / HA_LANG / NA_COUNTRY are exported by entrypoint.sh; filling them
+    # here makes the generated file complete on its own. migrate.py still injects
+    # them at startup for configs produced elsewhere (expert.json, older files).
+    inject_locale(config, os.environ.get("HA_COUNTRY", ""), os.environ.get("HA_LANG", ""),
+                  os.environ.get("NA_COUNTRY", ""))
+    return config
 
 
 def parse_config(config: dict[str, Any]) -> dict[str, Any]:

--- a/carconnectivity-addon-edge/rootfs/tmp/entrypoint.sh
+++ b/carconnectivity-addon-edge/rootfs/tmp/entrypoint.sh
@@ -173,6 +173,9 @@ NA_COUNTRY="us"
 if [ "${HA_COUNTRY}" = "ca" ]; then
     NA_COUNTRY="ca"
 fi
+# Exported so the configui generator can default country/language in the
+# configs it writes (migrate.py receives them explicitly at startup).
+export HA_COUNTRY HA_LANG NA_COUNTRY
 color_echo "${CYAN}" "🌍 Detected locale: ${LOCALE} / country: ${HA_COUNTRY} / language: ${HA_LANG}"
 
 # Expert mode is implicit: when a hand-written ${EXPERT_NAME} is present it takes


### PR DESCRIPTION
The config page generator now fills `country`/`language` for `vw_eu_data_act` and `country` for `volkswagen_na` from the HA locale at generation time, by reusing `migrate.inject_locale`. `entrypoint.sh` exports `HA_COUNTRY` / `HA_LANG` / `NA_COUNTRY` so the configui process sees them.

- The generated `carconnectivity.json` is now complete on its own (before, the country only existed in the runtime copy injected at startup).
- Explicit values always win (`inject_locale` only fills unset keys).
- The startup injection in `migrate.py` remains as the safety net for configs produced elsewhere (expert.json, files from older versions), so behaviour is unchanged for them.

Tested with a simulated environment: EU Data Act gets `country`+`language`, VW NA gets `country`, Volvo untouched, explicit override kept, and nothing is added when the variables are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)