### PR TITLE
fix(startup): boot with the default MQTT broker instead of stopping (#159)

### DIFF
--- a/carconnectivity-addon-edge/fix_CHANGELOG.md
+++ b/carconnectivity-addon-edge/fix_CHANGELOG.md
@@ -1,0 +1,1 @@
+- **MQTT**: an add-on whose saved configuration has no broker now starts anyway, with `core-mosquitto:1883` applied to the running configuration and a notice in the log, instead of stopping at boot. The saved file is left untouched: open the configuration page and save to store the value (#159)

--- a/carconnectivity-addon-edge/rootfs/opt/configui/const.py
+++ b/carconnectivity-addon-edge/rootfs/opt/configui/const.py
@@ -11,6 +11,13 @@ from __future__ import annotations
 STATE_PATH = "/config/carconnectivity.configui.json"
 CONFIG_PATH = "/config/carconnectivity.json"
 
+# CarConnectivity refuses to start without an MQTT broker, so an empty broker
+# field falls back to the Home Assistant Mosquitto add-on defaults (what the page
+# and DOCS advertise). Used when generating a config and when repairing one at
+# startup, hence here rather than in generator.py.
+DEFAULT_MQTT_BROKER = "core-mosquitto"
+DEFAULT_MQTT_PORT = 1883
+
 SOURCE_EU_DATA_ACT = "eu_data_act"
 SOURCE_MANUFACTURER = "manufacturer"
 SOURCE_AUTO = "auto"

--- a/carconnectivity-addon-edge/rootfs/opt/configui/generator.py
+++ b/carconnectivity-addon-edge/rootfs/opt/configui/generator.py
@@ -11,17 +11,12 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from const import KINDS, SOURCE_EU_DATA_ACT, connector_for, resolve_source
+from const import (DEFAULT_MQTT_BROKER, DEFAULT_MQTT_PORT, KINDS,
+                   SOURCE_EU_DATA_ACT, connector_for, resolve_source)
 from migrate import inject_locale
 
 _DEFAULT_LOG = "info"
 _DEFAULT_API_LOG = "error"
-# CarConnectivity refuses to start at all without a broker ("No MQTT broker
-# specified in config"), so an empty MQTT field must fall back to the Home
-# Assistant Mosquitto add-on defaults the page advertises (field placeholder and
-# hint) instead of producing a config that cannot boot.
-_DEFAULT_MQTT_BROKER = "core-mosquitto"
-_DEFAULT_MQTT_PORT = 1883
 
 _EU_BRAND_TO_KEY = {k["eu_brand"]: key for key, k in KINDS.items() if k.get("eu_brand")}
 _MANU_CONN_TO_KEY = {k["manufacturer_connector"]: key for key, k in KINDS.items() if k.get("manufacturer_connector")}
@@ -99,9 +94,9 @@ def build_config(state: dict[str, Any]) -> dict[str, Any]:
 
     mqtt = dict(settings.get("mqtt") or {})
     if not mqtt.get("broker"):
-        mqtt["broker"] = _DEFAULT_MQTT_BROKER
+        mqtt["broker"] = DEFAULT_MQTT_BROKER
     if not mqtt.get("port"):
-        mqtt["port"] = _DEFAULT_MQTT_PORT
+        mqtt["port"] = DEFAULT_MQTT_PORT
     mqtt["log_level"] = _plugin_level("mqtt")
     plugins: list[dict[str, Any]] = [{"type": "mqtt", "config": mqtt}]
 

--- a/carconnectivity-addon-edge/rootfs/opt/configui/migrate.py
+++ b/carconnectivity-addon-edge/rootfs/opt/configui/migrate.py
@@ -8,6 +8,9 @@ generated UI config), so the migration is not limited to the config page.
 Idempotent: a config already on EU Data Act is left unchanged. Other connectors
 (Volvo, Škoda/Audi/VW-NA manufacturer, …) are untouched.
 
+The same pass also fills a missing MQTT broker (see ensure_mqtt_broker), the one
+omission that stops CarConnectivity from starting at all.
+
 CLI:  python migrate.py <in.json> <out.json>   # prints migrated brand labels
 """
 from __future__ import annotations
@@ -17,7 +20,7 @@ import os
 import sys
 from typing import Any
 
-from const import KINDS
+from const import DEFAULT_MQTT_BROKER, DEFAULT_MQTT_PORT, KINDS
 
 
 def migrate_config(config: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
@@ -71,6 +74,31 @@ def inject_locale(config: dict[str, Any], country: str, lang: str, na_country: s
                 cfg["country"] = na_country
 
 
+def ensure_mqtt_broker(config: dict[str, Any]) -> bool:
+    """Fill an enabled mqtt plugin's missing broker/port. Returns True if it did.
+
+    CarConnectivity exits at startup when the broker is missing ("No MQTT broker
+    specified in config"), and a config page older than 0.8.17 could save one
+    without it. Repairing the RUNTIME copy makes such an addon boot again on
+    update instead of leaving the user with a container that never starts; the
+    source config is untouched, so the page still shows the field as they left it.
+    """
+    cc = config.get("carConnectivity") if isinstance(config, dict) else None
+    if not isinstance(cc, dict):
+        return False
+    for plugin in cc.get("plugins") or []:
+        if not isinstance(plugin, dict) or plugin.get("type") != "mqtt" or plugin.get("disabled"):
+            continue
+        cfg = plugin.setdefault("config", {})
+        if not isinstance(cfg, dict) or cfg.get("broker"):
+            return False
+        cfg["broker"] = DEFAULT_MQTT_BROKER
+        if not cfg.get("port"):
+            cfg["port"] = DEFAULT_MQTT_PORT
+        return True
+    return False
+
+
 def _ensure_unique_ids(connectors: list[dict[str, Any]]) -> None:
     """Give every connector a unique connector_id (migration can create duplicate
     vw_eu_data_act instances that would otherwise collide)."""
@@ -95,6 +123,7 @@ def main(argv: list[str]) -> int:
     config, migrated = migrate_config(config)
     inject_locale(config, os.environ.get("HA_COUNTRY", ""), os.environ.get("HA_LANG", ""),
                   os.environ.get("NA_COUNTRY", ""))
+    ensure_mqtt_broker(config)
     with open(argv[2], "w", encoding="utf-8") as fh:
         json.dump(config, fh, indent=2, ensure_ascii=False)
     # Printed for the entrypoint to surface in the addon log.

--- a/carconnectivity-addon-edge/rootfs/tmp/entrypoint.sh
+++ b/carconnectivity-addon-edge/rootfs/tmp/entrypoint.sh
@@ -237,6 +237,14 @@ fi
 if [ -n "${MIGRATED}" ]; then
     color_echo "${YELLOW}" "🔁 Migrated to EU Data Act: ${MIGRATED}"
 fi
+
+# migrate.py fills a missing MQTT broker in the runtime copy (without it
+# CarConnectivity exits at startup). Say so, since the source config still has
+# the field empty and the value only becomes permanent on the next save.
+MQTT_NO_BROKER=$(jq -r '[.carConnectivity.plugins[]? | select(.type == "mqtt") | select((.config.broker // "") == "")] | length' "${SRC_CONFIG}" 2>/dev/null || echo 0)
+if [ "${MQTT_NO_BROKER}" != "0" ] && [ -n "${MQTT_NO_BROKER}" ]; then
+    color_echo "${YELLOW}" "🔧 No MQTT broker in the configuration: using core-mosquitto:1883. Open the configuration page and save to store it."
+fi
 CONFIG_FILE=${RUNTIME_FILE}
 
 DEBUG_LEVEL=$(jq -r '.carConnectivity.log_level'  ${CONFIG_FILE} 2>/dev/null || echo "")

--- a/carconnectivity-addon/rootfs/opt/configui/const.py
+++ b/carconnectivity-addon/rootfs/opt/configui/const.py
@@ -11,6 +11,13 @@ from __future__ import annotations
 STATE_PATH = "/config/carconnectivity.configui.json"
 CONFIG_PATH = "/config/carconnectivity.json"
 
+# CarConnectivity refuses to start without an MQTT broker, so an empty broker
+# field falls back to the Home Assistant Mosquitto add-on defaults (what the page
+# and DOCS advertise). Used when generating a config and when repairing one at
+# startup, hence here rather than in generator.py.
+DEFAULT_MQTT_BROKER = "core-mosquitto"
+DEFAULT_MQTT_PORT = 1883
+
 SOURCE_EU_DATA_ACT = "eu_data_act"
 SOURCE_MANUFACTURER = "manufacturer"
 SOURCE_AUTO = "auto"

--- a/carconnectivity-addon/rootfs/opt/configui/generator.py
+++ b/carconnectivity-addon/rootfs/opt/configui/generator.py
@@ -11,17 +11,12 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from const import KINDS, SOURCE_EU_DATA_ACT, connector_for, resolve_source
+from const import (DEFAULT_MQTT_BROKER, DEFAULT_MQTT_PORT, KINDS,
+                   SOURCE_EU_DATA_ACT, connector_for, resolve_source)
 from migrate import inject_locale
 
 _DEFAULT_LOG = "info"
 _DEFAULT_API_LOG = "error"
-# CarConnectivity refuses to start at all without a broker ("No MQTT broker
-# specified in config"), so an empty MQTT field must fall back to the Home
-# Assistant Mosquitto add-on defaults the page advertises (field placeholder and
-# hint) instead of producing a config that cannot boot.
-_DEFAULT_MQTT_BROKER = "core-mosquitto"
-_DEFAULT_MQTT_PORT = 1883
 
 _EU_BRAND_TO_KEY = {k["eu_brand"]: key for key, k in KINDS.items() if k.get("eu_brand")}
 _MANU_CONN_TO_KEY = {k["manufacturer_connector"]: key for key, k in KINDS.items() if k.get("manufacturer_connector")}
@@ -99,9 +94,9 @@ def build_config(state: dict[str, Any]) -> dict[str, Any]:
 
     mqtt = dict(settings.get("mqtt") or {})
     if not mqtt.get("broker"):
-        mqtt["broker"] = _DEFAULT_MQTT_BROKER
+        mqtt["broker"] = DEFAULT_MQTT_BROKER
     if not mqtt.get("port"):
-        mqtt["port"] = _DEFAULT_MQTT_PORT
+        mqtt["port"] = DEFAULT_MQTT_PORT
     mqtt["log_level"] = _plugin_level("mqtt")
     plugins: list[dict[str, Any]] = [{"type": "mqtt", "config": mqtt}]
 

--- a/carconnectivity-addon/rootfs/opt/configui/migrate.py
+++ b/carconnectivity-addon/rootfs/opt/configui/migrate.py
@@ -8,6 +8,9 @@ generated UI config), so the migration is not limited to the config page.
 Idempotent: a config already on EU Data Act is left unchanged. Other connectors
 (Volvo, Škoda/Audi/VW-NA manufacturer, …) are untouched.
 
+The same pass also fills a missing MQTT broker (see ensure_mqtt_broker), the one
+omission that stops CarConnectivity from starting at all.
+
 CLI:  python migrate.py <in.json> <out.json>   # prints migrated brand labels
 """
 from __future__ import annotations
@@ -17,7 +20,7 @@ import os
 import sys
 from typing import Any
 
-from const import KINDS
+from const import DEFAULT_MQTT_BROKER, DEFAULT_MQTT_PORT, KINDS
 
 
 def migrate_config(config: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
@@ -71,6 +74,31 @@ def inject_locale(config: dict[str, Any], country: str, lang: str, na_country: s
                 cfg["country"] = na_country
 
 
+def ensure_mqtt_broker(config: dict[str, Any]) -> bool:
+    """Fill an enabled mqtt plugin's missing broker/port. Returns True if it did.
+
+    CarConnectivity exits at startup when the broker is missing ("No MQTT broker
+    specified in config"), and a config page older than 0.8.17 could save one
+    without it. Repairing the RUNTIME copy makes such an addon boot again on
+    update instead of leaving the user with a container that never starts; the
+    source config is untouched, so the page still shows the field as they left it.
+    """
+    cc = config.get("carConnectivity") if isinstance(config, dict) else None
+    if not isinstance(cc, dict):
+        return False
+    for plugin in cc.get("plugins") or []:
+        if not isinstance(plugin, dict) or plugin.get("type") != "mqtt" or plugin.get("disabled"):
+            continue
+        cfg = plugin.setdefault("config", {})
+        if not isinstance(cfg, dict) or cfg.get("broker"):
+            return False
+        cfg["broker"] = DEFAULT_MQTT_BROKER
+        if not cfg.get("port"):
+            cfg["port"] = DEFAULT_MQTT_PORT
+        return True
+    return False
+
+
 def _ensure_unique_ids(connectors: list[dict[str, Any]]) -> None:
     """Give every connector a unique connector_id (migration can create duplicate
     vw_eu_data_act instances that would otherwise collide)."""
@@ -95,6 +123,7 @@ def main(argv: list[str]) -> int:
     config, migrated = migrate_config(config)
     inject_locale(config, os.environ.get("HA_COUNTRY", ""), os.environ.get("HA_LANG", ""),
                   os.environ.get("NA_COUNTRY", ""))
+    ensure_mqtt_broker(config)
     with open(argv[2], "w", encoding="utf-8") as fh:
         json.dump(config, fh, indent=2, ensure_ascii=False)
     # Printed for the entrypoint to surface in the addon log.

--- a/carconnectivity-addon/rootfs/tmp/entrypoint.sh
+++ b/carconnectivity-addon/rootfs/tmp/entrypoint.sh
@@ -237,6 +237,14 @@ fi
 if [ -n "${MIGRATED}" ]; then
     color_echo "${YELLOW}" "🔁 Migrated to EU Data Act: ${MIGRATED}"
 fi
+
+# migrate.py fills a missing MQTT broker in the runtime copy (without it
+# CarConnectivity exits at startup). Say so, since the source config still has
+# the field empty and the value only becomes permanent on the next save.
+MQTT_NO_BROKER=$(jq -r '[.carConnectivity.plugins[]? | select(.type == "mqtt") | select((.config.broker // "") == "")] | length' "${SRC_CONFIG}" 2>/dev/null || echo 0)
+if [ "${MQTT_NO_BROKER}" != "0" ] && [ -n "${MQTT_NO_BROKER}" ]; then
+    color_echo "${YELLOW}" "🔧 No MQTT broker in the configuration: using core-mosquitto:1883. Open the configuration page and save to store it."
+fi
 CONFIG_FILE=${RUNTIME_FILE}
 
 DEBUG_LEVEL=$(jq -r '.carConnectivity.log_level'  ${CONFIG_FILE} 2>/dev/null || echo "")


### PR DESCRIPTION
Follow-up to #160 / 0.8.17. Same issue (#159), the half it does not cover.

0.8.17 stops a configuration without an MQTT broker from being produced, but it does not rescue the ones already saved. Those users update, and CarConnectivity still exits at boot with `No MQTT broker specified in config`: the add-on stays down until they think to open the configuration page and save again.

## Changes

- `migrate.ensure_mqtt_broker` fills `broker` / `port` on an enabled `mqtt` plugin that has none. It runs in `migrate.py`'s startup pass, next to the EU Data Act migration and the locale injection, so it applies to every config source (page, expert, legacy).
- Only the **runtime copy** is repaired. The saved file is deliberately untouched: the page keeps showing the field as the user left it, and saving is what makes the value permanent.
- The entrypoint logs `🔧 No MQTT broker in the configuration: using core-mosquitto:1883...` so the substitution is never silent.
- `DEFAULT_MQTT_BROKER` / `DEFAULT_MQTT_PORT` move to `const.py`, read by both the generator and the startup repair (`migrate` cannot import `generator`, which imports `migrate`).

## Testing

Verified locally against the reporter's exact config shape:

- a config with `mqtt` and no broker is repaired to `core-mosquitto:1883`, connectors untouched
- idempotent: a second pass changes nothing
- a user-supplied broker is never overwritten
- degraded shapes (no `carConnectivity`, no plugins, plugin list containing junk, disabled mqtt plugin) return False without raising
- the EU Data Act migration and `build_config` still behave as before
- end to end through the `migrate.py <in> <out>` CLI the entrypoint uses: runtime file repaired, source file byte-identical

Not tested: the `jq` guard that prints the log line (no jq in the dev environment). It is read-only and falls back to `0` on any error, so a mistake there costs the message, not the boot.

No version bump here: this ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)